### PR TITLE
gh-2: Raise exception 404 instead of return 404

### DIFF
--- a/wpyblog/views.py
+++ b/wpyblog/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.urls import reverse
 from django.views.decorators.cache import cache_page
 from django.core.cache import cache
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.utils.encoding import uri_to_iri
 from django.utils import translation
 
@@ -40,7 +40,7 @@ def get_single_post(request, post_id):
 
     post = get_post(post_id)
     if post is None:
-        return HttpResponse(status=404)
+        raise Http404()
 
     post = _process_post(post)
     post["slug"] = uri_to_iri(post["slug"])


### PR DESCRIPTION
because by raising 404 exception, we can return a consistent 404 error page.
https://docs.djangoproject.com/en/4.0/topics/http/views/#the-http404-exception

Issue: gh-2